### PR TITLE
Use a modern PBR package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
+pbr>=1.8
 lxml>=3.4.1
 oslo.concurrency>=2.1.0
 oslo.context
 oslo.i18n>=1.5.0
 oslo.log>=1.2.0
 oslo.utils>=1.9.0
-pbr>=1.3,<2.0
 pyasn1-modules
 pyasn1
 pytz>=2013.6


### PR DESCRIPTION
The 2.0.0 is breaking in that it removes the use of warnerrors in
build_sphinux.

pypowervm isn't using that feature, so it shoudln't break.

The cap on pbr is preventing OpenStack projects that would like to
use pbr 2.0.0 (and sphinx 1.5.1) from doing so as it breaks
co-installability with pypowervm

Related-Bug: https://bugs.launchpad.net/openstack-requirements/+bug/1668848