### PR TITLE
Remove 'futures' dependency

### DIFF
--- a/pypowervm/tests/helpers/test_loghelper.py
+++ b/pypowervm/tests/helpers/test_loghelper.py
@@ -16,8 +16,8 @@
 
 import functools
 import logging as base_logging
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.adapter as adp
 import pypowervm.const as c

--- a/pypowervm/tests/helpers/test_sample.py
+++ b/pypowervm/tests/helpers/test_sample.py
@@ -15,8 +15,8 @@
 #    under the License.
 
 import functools
+from unittest import mock
 
-import mock
 import testtools
 
 import pypowervm.adapter as adp

--- a/pypowervm/tests/helpers/test_vios_busy.py
+++ b/pypowervm/tests/helpers/test_vios_busy.py
@@ -15,9 +15,9 @@
 #    under the License.
 
 import functools
+from unittest import mock
 import unittest
 
-import mock
 
 import pypowervm.adapter as adp
 import pypowervm.exceptions as pvmex

--- a/pypowervm/tests/tasks/hdisk/test_fc.py
+++ b/pypowervm/tests/tasks/hdisk/test_fc.py
@@ -14,7 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
 
 import unittest
 

--- a/pypowervm/tests/tasks/hdisk/test_iscsi.py
+++ b/pypowervm/tests/tasks/hdisk/test_iscsi.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.entities as ent
 from pypowervm import exceptions as pexc

--- a/pypowervm/tests/tasks/hdisk/test_rbd.py
+++ b/pypowervm/tests/tasks/hdisk/test_rbd.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.entities as ent
 from pypowervm.tasks.hdisk import _rbd as rbd

--- a/pypowervm/tests/tasks/monitor/test_host_cpu.py
+++ b/pypowervm/tests/tasks/monitor/test_host_cpu.py
@@ -15,8 +15,8 @@
 #    under the License.
 
 import logging
-import mock
 import testtools
+from unittest import mock
 
 from pypowervm.tasks.monitor import host_cpu
 import pypowervm.tests.test_fixtures as pvm_fx

--- a/pypowervm/tests/tasks/monitor/test_monitor.py
+++ b/pypowervm/tests/tasks/monitor/test_monitor.py
@@ -17,8 +17,8 @@
 """Test for the monitoring functions."""
 
 import datetime
+from unittest import mock
 
-import mock
 import testtools
 
 from pypowervm import entities as pvm_e

--- a/pypowervm/tests/tasks/test_cluster_ssp.py
+++ b/pypowervm/tests/tasks/test_cluster_ssp.py
@@ -14,8 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
+
 import fixtures
-import mock
 import unittest
 import uuid
 

--- a/pypowervm/tests/tasks/test_cna.py
+++ b/pypowervm/tests/tasks/test_cna.py
@@ -15,7 +15,7 @@
 #    under the License.
 
 
-import mock
+from unittest import mock
 
 from pypowervm import adapter as adp
 from pypowervm import exceptions as exc

--- a/pypowervm/tests/tasks/test_ibmi.py
+++ b/pypowervm/tests/tasks/test_ibmi.py
@@ -15,8 +15,9 @@
 #    under the License.
 
 
+from unittest import mock
+
 import fixtures
-import mock
 import testtools
 
 from pypowervm import exceptions as pvm_exc

--- a/pypowervm/tests/tasks/test_master_mode.py
+++ b/pypowervm/tests/tasks/test_master_mode.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.entities as ent
 from pypowervm.tasks import master_mode as m_mode

--- a/pypowervm/tests/tasks/test_memory.py
+++ b/pypowervm/tests/tasks/test_memory.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.entities as ent
 from pypowervm.tasks import memory

--- a/pypowervm/tests/tasks/test_mgmtconsole.py
+++ b/pypowervm/tests/tasks/test_mgmtconsole.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 from pypowervm import const
 from pypowervm import exceptions as exc

--- a/pypowervm/tests/tasks/test_migration.py
+++ b/pypowervm/tests/tasks/test_migration.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.entities as ent
 from pypowervm.tasks import migration as mig

--- a/pypowervm/tests/tasks/test_network_bridger.py
+++ b/pypowervm/tests/tasks/test_network_bridger.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 from oslo_config.cfg import CONF
 

--- a/pypowervm/tests/tasks/test_partition.py
+++ b/pypowervm/tests/tasks/test_partition.py
@@ -16,8 +16,8 @@
 
 """Tests for pypowervm.tasks.partition."""
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.const as c
 import pypowervm.entities as ent

--- a/pypowervm/tests/tasks/test_power.py
+++ b/pypowervm/tests/tasks/test_power.py
@@ -14,8 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
+
 import fixtures
-import mock
 import testtools
 
 import pypowervm.exceptions as pexc

--- a/pypowervm/tests/tasks/test_power_opts.py
+++ b/pypowervm/tests/tasks/test_power_opts.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.exceptions as exc
 import pypowervm.tasks.power_opts as popts

--- a/pypowervm/tests/tasks/test_scsi_mapper.py
+++ b/pypowervm/tests/tasks/test_scsi_mapper.py
@@ -15,8 +15,8 @@
 #    under the License.
 
 
-import mock
 import testtools
+from unittest import mock
 
 from pypowervm import exceptions as exc
 from pypowervm.tasks import scsi_mapper

--- a/pypowervm/tests/tasks/test_slot_map.py
+++ b/pypowervm/tests/tasks/test_slot_map.py
@@ -15,7 +15,8 @@
 #    under the License.
 """Test pypowervm.tasks.slot_map."""
 
-import mock
+from unittest import mock
+
 import six
 import testtools
 

--- a/pypowervm/tests/tasks/test_sriov.py
+++ b/pypowervm/tests/tasks/test_sriov.py
@@ -16,8 +16,8 @@
 
 """Tests for pypowervm.tasks.sriov."""
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.exceptions as ex
 import pypowervm.tasks.sriov as tsriov

--- a/pypowervm/tests/tasks/test_storage.py
+++ b/pypowervm/tests/tasks/test_storage.py
@@ -14,10 +14,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
+
 from six.moves import builtins
 
 import fixtures
-import mock
 import testtools
 
 import pypowervm.adapter as adp

--- a/pypowervm/tests/tasks/test_vfc_mapper.py
+++ b/pypowervm/tests/tasks/test_vfc_mapper.py
@@ -14,9 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
 import unittest
 
-import mock
 
 from pypowervm import const as c
 from pypowervm import exceptions as e

--- a/pypowervm/tests/tasks/test_vopt.py
+++ b/pypowervm/tests/tasks/test_vopt.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 from pypowervm import exceptions as pvm_ex
 from pypowervm.tasks import vopt

--- a/pypowervm/tests/tasks/test_vterm.py
+++ b/pypowervm/tests/tasks/test_vterm.py
@@ -14,7 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
+
 import six
 import testtools
 

--- a/pypowervm/tests/test_adapter.py
+++ b/pypowervm/tests/test_adapter.py
@@ -16,13 +16,14 @@
 
 import copy
 import errno
+from unittest import mock
+
 import fixtures
 from lxml import etree
 import six
 import subunit
 
 
-import mock
 import requests.models as req_mod
 import requests.structures as req_struct
 import testtools

--- a/pypowervm/tests/test_fixtures.py
+++ b/pypowervm/tests/test_fixtures.py
@@ -16,9 +16,10 @@
 #
 
 import abc
+from unittest import mock
+
 import fixtures
 import importlib
-import mock
 import six
 
 from pypowervm import traits as trt

--- a/pypowervm/tests/test_helpers.py
+++ b/pypowervm/tests/test_helpers.py
@@ -15,9 +15,9 @@
 #    under the License.
 
 import functools
+from unittest import mock
 import unittest
 
-import mock
 
 import pypowervm.adapter as adp
 

--- a/pypowervm/tests/test_i18n.py
+++ b/pypowervm/tests/test_i18n.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import os
+from unittest import mock
 import unittest
 
 from pypowervm.i18n import _

--- a/pypowervm/tests/test_session.py
+++ b/pypowervm/tests/test_session.py
@@ -16,13 +16,13 @@
 
 import copy
 import gc
-import mock
 import os
 import requests.models as req_mod
 import requests.structures as req_struct
 import subunit
 import sys
 import testtools
+from unittest import mock
 
 import pypowervm.adapter as adp
 import pypowervm.exceptions as pvmex

--- a/pypowervm/tests/test_traits.py
+++ b/pypowervm/tests/test_traits.py
@@ -14,9 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
 import unittest
 
-import mock
 import requests.models as req_mod
 import requests.structures as req_struct
 

--- a/pypowervm/tests/test_util.py
+++ b/pypowervm/tests/test_util.py
@@ -14,7 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
+
 import six
 
 

--- a/pypowervm/tests/utils/test_lpar_bldr.py
+++ b/pypowervm/tests/utils/test_lpar_bldr.py
@@ -14,9 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
 import uuid
 
-import mock
 import six
 import testtools
 

--- a/pypowervm/tests/utils/test_retry.py
+++ b/pypowervm/tests/utils/test_retry.py
@@ -14,9 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import random
 import testtools
+from unittest import mock
 
 from pypowervm import adapter as adpt
 from pypowervm import const as c

--- a/pypowervm/tests/utils/test_transaction.py
+++ b/pypowervm/tests/utils/test_transaction.py
@@ -17,7 +17,8 @@
 """Tests for pypowervm.utils.transaction."""
 
 import copy
-import mock
+from unittest import mock
+
 import oslo_concurrency.lockutils as lock
 import oslo_context.context as ctx
 from taskflow import engines as tf_eng

--- a/pypowervm/tests/utils/test_validation.py
+++ b/pypowervm/tests/utils/test_validation.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 from pypowervm.utils import validation as vldn
 from pypowervm.wrappers import base_partition as bp

--- a/pypowervm/tests/wrappers/test_entry.py
+++ b/pypowervm/tests/wrappers/test_entry.py
@@ -16,11 +16,11 @@
 
 import copy
 import re
+from unittest import mock
 import unittest
 import uuid
 
 from lxml import etree
-import mock
 import six
 import testtools
 

--- a/pypowervm/tests/wrappers/test_event.py
+++ b/pypowervm/tests/wrappers/test_event.py
@@ -14,7 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
+from unittest import mock
 
 import pypowervm.tests.test_utils.test_wrapper_abc as twrap
 from pypowervm.wrappers import event

--- a/pypowervm/tests/wrappers/test_http_error.py
+++ b/pypowervm/tests/wrappers/test_http_error.py
@@ -14,9 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
 import unittest
 
-import mock
 
 from pypowervm.tests.test_utils import pvmhttp
 import pypowervm.wrappers.http_error as he

--- a/pypowervm/tests/wrappers/test_job.py
+++ b/pypowervm/tests/wrappers/test_job.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.exceptions as ex
 import pypowervm.tests.test_fixtures as fx

--- a/pypowervm/tests/wrappers/test_logical_partition.py
+++ b/pypowervm/tests/wrappers/test_logical_partition.py
@@ -14,10 +14,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from unittest import mock
 import unittest
 import uuid
 
-import mock
 import testtools
 
 import pypowervm.tests.test_fixtures as fx

--- a/pypowervm/tests/wrappers/test_network.py
+++ b/pypowervm/tests/wrappers/test_network.py
@@ -15,9 +15,9 @@
 #    under the License.
 
 import copy
+from unittest import mock
 import unittest
 
-import mock
 
 import pypowervm.const as pc
 import pypowervm.tests.test_fixtures as fx

--- a/pypowervm/tests/wrappers/test_storage.py
+++ b/pypowervm/tests/wrappers/test_storage.py
@@ -14,8 +14,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import mock
 import testtools
+from unittest import mock
 
 import pypowervm.const as pc
 import pypowervm.exceptions as ex

--- a/pypowervm/tests/wrappers/test_virtual_io_server.py
+++ b/pypowervm/tests/wrappers/test_virtual_io_server.py
@@ -15,7 +15,7 @@
 #    under the License.
 
 import copy
-import mock
+from unittest import mock
 import unittest
 
 import pypowervm.adapter as adpt

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,5 @@ pyasn1 # BSD
 pytz>=2019.3 # MIT
 requests!=2.12.2,!=2.13.0,>=2.10.0 # Apache-2.0
 six>=1.14.0 # MIT
-futures>=3.0;python_version=='3.6' # BSD
 Taskflow>=3.8.0 # Apache-2.0
 babel

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,6 @@ classifier =
 [files]
 packages = pypowervm
 
-[build_sphinx]
-source-dir = doc/source
-build-dir = doc/build
-all_files = 1
-
-[upload_sphinx]
-upload-dir = doc/build/html
-
 [compile_catalog]
 directory = pypowervm/locale
 domain = pypowervm
@@ -44,6 +36,3 @@ input_file = pypowervm/locale/pypowervm.pot
 keywords = _ gettext ngettext l_ lazy_gettext
 mapping_file = babel.cfg
 output_file = pypowervm/locale/pypowervm.pot
-
-[bdist_wheel]
-universal = 1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
-# The order of packages is significant, because pip processes them in the order
-# of appearance.
 hacking!=0.13.0,>=0.12.0
 
 coverage>=4.0,<=5.0.3 # Apache-2.0
@@ -9,4 +7,3 @@ pylint>=1.4.5 # GPLv2
 python-subunit>=0.0.18 # Apache-2.0/BSD
 stestr>=1.0.0 # Apache-2.0
 testtools>=1.4.0 # MIT
-mock>=2.0 # BSD

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,10 +7,6 @@ discover
 fixtures>=3.0.0 # Apache-2.0/BSD
 pylint>=1.4.5 # GPLv2
 python-subunit>=0.0.18 # Apache-2.0/BSD
-setuptools<45.0.0
-sphinx>=1.5.1 # BSD
-oslosphinx>=4.7.0 # Apache-2.0
 stestr>=1.0.0 # Apache-2.0
-testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=1.4.0 # MIT
 mock>=2.0 # BSD

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 minversion = 1.6
 envlist = py{36},pep8
-skipsdist = True
+skipsdist = true
+# Automatic envs (pyXX) will only use the python version appropriate to that
+# env and ignore basepython inherited from [testenv] if we set
+# ignore_basepython_conflict.
+ignore_basepython_conflict = true
 
 [testenv]
+basepython = python3
 usedevelop = True
-install_command = pip install {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
@@ -13,26 +17,17 @@ setenv =
   OS_STDOUT_CAPTURE=1
   OS_STDERR_CAPTURE=1
   OS_TEST_TIMEOUT=60
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/test-requirements.txt
-whitelist_externals =
-  find
-  sonar-runner
+  PYTHONDONTWRITEBYTECODE=1
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
 commands =
-  find . -type f -name "*.pyc" -delete
-
-[testenv:py36]
-# TODO(efried): Remove this once https://github.com/tox-dev/tox/issues/425 is fixed.
-basepython = python3
-commands =
-  {[testenv]commands}
   stestr run {posargs}
   stestr slowest
 
 [testenv:pep8]
-# TODO(efried): Remove this once https://github.com/tox-dev/tox/issues/425 is fixed.
-basepython = python3
-commands = flake8 --ignore=W504,W503,E731,H214,H216
+commands =
+  flake8 --ignore=W504,W503,E731,H214,H216
 
 [testenv:venv]
 basepython = python3
@@ -48,7 +43,6 @@ setenv =
   {[testenv]setenv}
   PYTHON=coverage run --source pypowervm --parallel-mode
 commands =
-  {[testenv]commands}
   coverage erase
   stestr run {posargs}
   coverage combine
@@ -58,13 +52,17 @@ commands =
 
 [flake8]
 ignore =
-exclude =  .venv,.git,.tox,*egg
+exclude = .venv,.git,.tox,*egg
 
 [hacking]
 local-check-factory = pypowervm.hacking.checks.factory
 
 [testenv:pylint]
-commands = pylint pypowervm --rcfile=.pylint.rc
+commands =
+  pylint pypowervm --rcfile=.pylint.rc
 
 [testenv:sonar]
-commands = sonar-runner -Dsonar.login={env:SONAR_USER:} -Dsonar.password={env:SONAR_PASSWORD:} -Dsonar.analysis.mode=incremental -Dsonar.scm-stats.enabled=false -Dsonar.scm.enabled=false -Dsonar.host.url=http://{env:SONAR_SERVER:sonar-server}:9000 -Dsonar.jdbc.url=jdbc:mysql://{env:SONAR_SERVER:sonar-server}:3306/sonar
+whitelist_externals =
+  sonar-runner
+commands =
+  sonar-runner -Dsonar.login={env:SONAR_USER:} -Dsonar.password={env:SONAR_PASSWORD:} -Dsonar.analysis.mode=incremental -Dsonar.scm-stats.enabled=false -Dsonar.scm.enabled=false -Dsonar.host.url=http://{env:SONAR_SERVER:sonar-server}:9000 -Dsonar.jdbc.url=jdbc:mysql://{env:SONAR_SERVER:sonar-server}:3306/sonar


### PR DESCRIPTION
The 'futures' dependency doesn't actually work with Python 3.6, or any Python 3.x release. We shouldn't be installing it in that environment and attempting to do so is an error with the most recent pip dependency resolver, which is in turn breaking unit tests for e.g. openstack nova. Remove the dependency. Testing this necessitates some surgery on the tox.ini file to ensure I can actually run tests with Python 3.6 on my host (Fedora 34 where 'python3' points to Python 3.9).

Note that I found references to a Gerrit instance, but I wasn't able to figure out *which* Gerrit instance I should use, and the '.gitreview' file is not configured with this information. If this is an internal instance, I'd respectfully ask that someone take these commits and apply them for me.